### PR TITLE
Track layout

### DIFF
--- a/frontend/app/controllers.js
+++ b/frontend/app/controllers.js
@@ -412,7 +412,8 @@ angular.module('acServerManager')
 			var track = findInArray($scope.tracks, {name: $scope.selectedTracks})
 			if (track !== null) {
 
-				if (track.configs && track.configs.length && $scope.server.CONFIG_TRACK != 'Default_layout') {
+				//if (track.configs && track.configs.length && $scope.server.CONFIG_TRACK != 'Default_layout') {
+				if (track.configs && track.configs.length) {
 					$scope.configs = track.configs;
 					var index = $scope.configs.indexOf($scope.server.CONFIG_TRACK);
 					var index = (index !== -1) ? index : 0;
@@ -422,12 +423,11 @@ angular.module('acServerManager')
 						$scope.trackDetails = data;
 					});
 
-					$scope.trackImage = '/api/tracks/' + $scope.selectedTracks + '/' + $scope.server.CONFIG_TRACK + '/image';
+					var trackImagePath = '/api/tracks/' + $scope.selectedTracks + '/' + $scope.server.CONFIG_TRACK + '/image';
+					$scope.trackImage = trackImagePath.replace("/Default_layout", "");
 				} else {
-					if($scope.server.CONFIG_TRACK != 'Default_layout'){
-						$scope.configs = null;
-						$scope.server.CONFIG_TRACK = '';
-					}
+					$scope.configs = null;
+					$scope.server.CONFIG_TRACK = '';
 
 					TrackService.GetTrackDetails(track.name, null, function(data) {
 						$scope.trackDetails = data;

--- a/frontend/app/controllers.js
+++ b/frontend/app/controllers.js
@@ -411,21 +411,24 @@ angular.module('acServerManager')
 		$scope.trackChanged = function() {
 			var track = findInArray($scope.tracks, {name: $scope.selectedTracks})
 			if (track !== null) {
-				if (track.configs && track.configs.length) {
+
+				if (track.configs && track.configs.length && $scope.server.CONFIG_TRACK != 'Default_layout') {
 					$scope.configs = track.configs;
 					var index = $scope.configs.indexOf($scope.server.CONFIG_TRACK);
 					var index = (index !== -1) ? index : 0;
 					$scope.server.CONFIG_TRACK = $scope.configs[index];
-					
+
 					TrackService.GetTrackDetails(track.name, $scope.server.CONFIG_TRACK, function(data) {
 						$scope.trackDetails = data;
 					});
-					
+
 					$scope.trackImage = '/api/tracks/' + $scope.selectedTracks + '/' + $scope.server.CONFIG_TRACK + '/image';
 				} else {
-					$scope.configs = null;
-					$scope.server.CONFIG_TRACK = '';
-					
+					if($scope.server.CONFIG_TRACK != 'Default_layout'){
+						$scope.configs = null;
+						$scope.server.CONFIG_TRACK = '';
+					}
+
 					TrackService.GetTrackDetails(track.name, null, function(data) {
 						$scope.trackDetails = data;
 					});

--- a/frontend/app/services.js
+++ b/frontend/app/services.js
@@ -26,7 +26,10 @@ angular.module('acServerManager.services', ['ngResource']).
                 });
             },
 			GetTrackDetails: function(track, config, callback) {
-				if (config) {
+
+                // "default layout" loads the main track data
+                // Todo, make "Default_layout" configurable
+				if (config && config != "Default_layout") {
 					var resource = $resource('/api/tracks/:track/:config');
 					var result = resource.get({track: track, config: config}, function() {
 						callback(result);

--- a/frontend/server.html
+++ b/frontend/server.html
@@ -168,6 +168,16 @@
 											<label>Cars</label>
 											<select multiple size="10" class="form-control" ng-model="selectedCars" ng-options="car as car for car in cars" ng-change="carsChanged()"></select>
 										</div>
+
+										<div class="form-group">
+											<label>Tyres</label>
+
+											<div ng-repeat="tyre in tyres">
+												<label><input type="checkbox" style="margin-right: 5px;" ng-model="tyre.isChecked" value="{{tyre.value}}" ng-change="tyresChanged(tyre)">{{tyre.description}}</label>
+											</div>
+
+										</div>
+
 									</div>
 									
 									<div class="col-sm-6">
@@ -208,18 +218,6 @@
 									</div>
 								</div>
 								
-								<div class="row">
-									<div class="col-sm-12">
-										<div class="form-group">
-											<label>Tyres</label>
-
-                                            <div ng-repeat="tyre in tyres">
-                                                <label><input type="checkbox" style="margin-right: 5px;" ng-model="tyre.isChecked" value="{{tyre.value}}" ng-change="tyresChanged(tyre)">{{tyre.description}}</label>
-                                            </div>
-
-										</div>
-									</div>
-								</div>
 							</fieldset>
 							
 							<fieldset class="top10">

--- a/frontend/server.html
+++ b/frontend/server.html
@@ -184,7 +184,7 @@
 											<div class="col-sm-12">
 												<div class="form-group">
 													<label>Configuration</label>
-													<select class="form-control" ng-model="server.CONFIG_TRACK" ng-options="config as config for config in configs"></select>
+													<select class="form-control" ng-model="server.CONFIG_TRACK" ng-options="config as config for config in configs" ng-change="trackChanged()"></select>
 												</div>
 											</div>
 										</div>

--- a/server.js
+++ b/server.js
@@ -600,17 +600,12 @@ app.get('/api/tracks', function (req, res) {
 
 			try {
 				var configs = getDirectories(contentPath + '/tracks/' + trackNames[trackName] + '/ui');
-				console.log("1 "+configs);
-
 				var singleLayout = isSingleLayout(contentPath + '/tracks/' + trackNames[trackName] + '/ui');
 
 				if(singleLayout && configs.length > 0){
-					console.log("Adding empty for "+contentPath + '/tracks/' + trackNames[trackName] + '/ui');
 					configs.push('Default_layout');
-				} else {
-					console.log("ei ollut singlelayout");
 				}
-				console.log("2 "+configs);
+
 				track.configs = configs;
 			}
 			catch (e) {

--- a/server.js
+++ b/server.js
@@ -74,6 +74,18 @@ function getDirectories(srcpath) {
 	}
 }
 
+function isSingleLayout(srcpath){
+	try {
+		return fs.readFileSync(srcpath+'/ui_track.json', 'utf8');
+
+	} catch (e) {
+
+		return false;
+	}
+
+
+}
+
 function getDateTimeString() {
 	try {
 		var d = new Date();
@@ -536,7 +548,6 @@ app.post('/api/dynamictrack/:id', function (req, res) {
 app.get('/api/weather', function (req, res) {
 	try {
 		var weather = [];
-
 		Object.keys(config).forEach(function (key) {
 			if (key.indexOf('WEATHER_') === 0) {
 				weather.push(config[key]);
@@ -589,6 +600,17 @@ app.get('/api/tracks', function (req, res) {
 
 			try {
 				var configs = getDirectories(contentPath + '/tracks/' + trackNames[trackName] + '/ui');
+				console.log("1 "+configs);
+
+				var singleLayout = isSingleLayout(contentPath + '/tracks/' + trackNames[trackName] + '/ui');
+
+				if(singleLayout && configs.length > 0){
+					console.log("Adding empty for "+contentPath + '/tracks/' + trackNames[trackName] + '/ui');
+					configs.push('Default_layout');
+				} else {
+					console.log("ei ollut singlelayout");
+				}
+				console.log("2 "+configs);
 				track.configs = configs;
 			}
 			catch (e) {
@@ -640,7 +662,7 @@ app.get('/api/tracks/:track/image', function (req, res) {
 app.get('/api/tracks/:track/:config', function (req, res) {
 	try {
 		contentPath = checkLocalContentPath(contentPath);
-		var trackDetails = fs.readFileSync(contentPath + '/tracks/' + req.params.track + '/ui/' + req.params.config + '/ui_track.json', 'utf-8');
+		var trackDetails = fs.readFileSync(contentPath + '/tracks/' + req.params.track + '/ui/' + req.params.config.replace('Default_layout','') + '/ui_track.json', 'utf-8');
 		res.status(200);
 		res.send(trackDetails);
 	} catch (e) {
@@ -654,7 +676,7 @@ app.get('/api/tracks/:track/:config', function (req, res) {
 app.get('/api/tracks/:track/:config/image', function (req, res) {
 	try {
 		contentPath = checkLocalContentPath(contentPath);
-		var image = fs.readFileSync(contentPath + '/tracks/' + req.params.track + '/ui/' + req.params.config + '/preview.png');
+		var image = fs.readFileSync(contentPath + '/tracks/' + req.params.track + '/ui/' + req.params.config.replace('Default_layout','') + '/preview.png');
 		res.status(200);
 		res.contentType('image/jpeg');
 		res.send(image);


### PR DESCRIPTION
If track initially without extra layouts is modified or it gets additional layouts handle the original layout in it's main directory by adding virtual 'Default_layout' for it

- detect tracks with originally only one layout, then add default_layout to their possible config for it
- when getting track data remove default_layout from configs, and load it from original 'root' directory
- adds change handler for configs so that ui_track.json gets loaded when config changes
- moves tyre selection inside car selection column to prevent unneeded whites pace between them